### PR TITLE
fix: correct projection toggle behavior

### DIFF
--- a/packages/fossflow-lib/src/components/Grid/Grid.tsx
+++ b/packages/fossflow-lib/src/components/Grid/Grid.tsx
@@ -20,6 +20,9 @@ export const Grid = () => {
   useEffect(() => {
     if (!elementRef.current) return;
 
+    // Update the grid graphic when switching projections
+    elementRef.current.style.backgroundImage = `url("${projection === 'TOP' ? gridTopTileSvg : gridTileSvg}")`;
+
     const baseTile =
       projection === 'TOP'
         ? { width: UNPROJECTED_TILE_SIZE, height: UNPROJECTED_TILE_SIZE }
@@ -65,7 +68,7 @@ export const Grid = () => {
           position: 'absolute',
           width: '100%',
           height: '100%',
-          background: `repeat url("${projection === 'TOP' ? gridTopTileSvg : gridTileSvg}")`
+          backgroundRepeat: 'repeat'
         }}
       />
     </Box>

--- a/packages/fossflow-lib/src/hooks/useIsoProjection.ts
+++ b/packages/fossflow-lib/src/hooks/useIsoProjection.ts
@@ -39,8 +39,11 @@ export const useIsoProjection = ({
 
     const boundingBox = getBoundingBox([from, to]);
 
-    return boundingBox[3];
-  }, [from, to, originOverride]);
+    // In top view we use the top-left corner so items retain their
+    // grid position when switching projections. Isometric view still
+    // relies on the bottom-left corner.
+    return projection === 'TOP' ? boundingBox[0] : boundingBox[3];
+  }, [from, to, originOverride, projection]);
 
   const position = useMemo(() => {
     if (projection === 'TOP') {


### PR DESCRIPTION
## Summary
- ensure top-view items retain grid positions by using top-left origin
- update grid background when switching projections

## Testing
- `npm test` *(fails: SyntaxError in packages/fossflow-lib/jest.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a65c9d3d80832aa98bf2879f6c0c57